### PR TITLE
Update to support node-pixrem master

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function(root, options) {
     }
 
     try {
-      file.contents = new Buffer(pixrem(file.contents.toString(), root, options));
+      file.contents = new Buffer(pixrem.process(file.contents.toString(), root, options));
     } catch (err) {
       this.emit('error', new gutil.PluginError('gulp-pixrem', err));
     }


### PR DESCRIPTION
The current master version of node-pixrem has been refactored and as such this plugin breaks - this is just a simple patch so when node-pixrem is finally tagged to a new version this will be able to carry on working.